### PR TITLE
misc: Patch ethos-u core driver URL after TFLM checkout.

### DIFF
--- a/.github/workflows/tflm.yml
+++ b/.github/workflows/tflm.yml
@@ -51,6 +51,11 @@ jobs:
         repository: tensorflow/tflite-micro
         ref: a57349f0bc3bc3ded105238fe2f14c36888d42b0
 
+    - name: '🔧 Patch TFLM ethos-u URL'
+      run: |
+        sed -i 's|https://review.mlplatform.org/ml/ethos-u/ethos-u-core-driver|https://gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-core-driver|g' \
+          tflite-micro/tensorflow/lite/micro/tools/make/ethos_u_core_driver_download.sh
+
     - name: '♻ Caching dependencies'
       uses: actions/cache@v4
       id: cache


### PR DESCRIPTION
The upstream ethos-u-core-driver repo moved from review.mlplatform.org to gitlab.arm.com. Patch the download script post-checkout to fix the build without updating the pinned TFLM commit.