### PR TITLE
misc: Update ARM GCC toolchain to 14.3.rel1.

### DIFF
--- a/.github/workflows/tflm.yml
+++ b/.github/workflows/tflm.yml
@@ -61,7 +61,7 @@ jobs:
       id: cache
       with:
         path: ~/cache/gcc
-        key: 'arm-gnu-toolchain-13.2.rel1'
+        key: 'arm-gnu-toolchain-14.3.rel1'
 
     - name: '🛠 Install toolchain '
       if: steps.cache.outputs.cache-hit != 'true'

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -11,7 +11,7 @@
 TFLM_REPO_PATH=tflite-micro
 TOOLCHAIN_PATH=${HOME}/cache/gcc
 export PATH=${TOOLCHAIN_PATH}/bin:${PATH}
-TOOLCHAIN_URL="https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz"
+TOOLCHAIN_URL="https://developer.arm.com/-/media/Files/downloads/gnu/14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-x86_64-arm-none-eabi.tar.xz"
 
 ci_install_arm_gcc() {
     mkdir -p ${TOOLCHAIN_PATH}


### PR DESCRIPTION
GCC 14.3+ is required for proper Cortex-M55 support, matching the toolchain used in the main openmv build.